### PR TITLE
Add environment variables for MQTT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ You can use environment variables to control the behavior.
 | `HOMEASSISTANT_PREFIX` | `homeassistant` | The prefix for Home Assistant discovery. Must be the same as `discovery_prefix` in your Home Assistant configuration. |
 | `HOSTLIST` | `localhost:127.0.0.1` | A comma separated list of hosts to ping. This is the valid grammar for each host entry: `<hostname[:ip_address]>` |
 | `MQTT_CLIENT_ID` | `mqtt2discord` | The client id to send to the MQTT broker. |
-| `MQTT_USER` | `` | The user to send to the MQTT broker. |
-| `MQTT_PASSWD` | `` | The password to send to the MQTT broker. |
+| `MQTT_USER` | `` | The user to send to the MQTT broker. Leave unset to disable authentication. |
+| `MQTT_PASSWD` | `` | The password to send to the MQTT broker. Leave unset to disable authentication. |
 | `MQTT_HOST` | `localhost` | The MQTT broker to connect to. |
 | `MQTT_PORT` | `1883` | The port on the broker to connect to. |
 | `MQTT_TIMEOUT` | `300` | The timeout for the MQTT connection. |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ services:
     - HOMEASSISTANT_PREFIX=homeassistant
     - HOSTLIST=router.local:192.168.1.1,internet.gw:10.10.10.1
     - MQTT_CLIENT_ID=ping2mqtt
+    - MQTT_USER=username
+    - MQTT_PASSWD=password
     - MQTT_HOST=mosquitto
     - MQTT_PORT=1883
     - MQTT_TIMEOUT=300
@@ -37,6 +39,8 @@ You can use environment variables to control the behavior.
 | `HOMEASSISTANT_PREFIX` | `homeassistant` | The prefix for Home Assistant discovery. Must be the same as `discovery_prefix` in your Home Assistant configuration. |
 | `HOSTLIST` | `localhost:127.0.0.1` | A comma separated list of hosts to ping. This is the valid grammar for each host entry: `<hostname[:ip_address]>` |
 | `MQTT_CLIENT_ID` | `mqtt2discord` | The client id to send to the MQTT broker. |
+| `MQTT_USER` | `` | The user to send to the MQTT broker. |
+| `MQTT_PASSWD` | `` | The password to send to the MQTT broker. |
 | `MQTT_HOST` | `localhost` | The MQTT broker to connect to. |
 | `MQTT_PORT` | `1883` | The port on the broker to connect to. |
 | `MQTT_TIMEOUT` | `300` | The timeout for the MQTT connection. |

--- a/ping2mqtt
+++ b/ping2mqtt
@@ -16,6 +16,8 @@ DEBUG = environ.get('DEBUG') == '1'
 HOMEASSISTANT_PREFIX = environ.get('HOMEASSISTANT_PREFIX', 'homeassistant')
 HOSTLIST = environ.get('HOSTLIST', 'localhost:127.0.0.1')
 MQTT_CLIENT_ID = environ.get('MQTT_CLIENT_ID', 'ping2mqtt')
+MQTT_USER = environ.get('MQTT_USER', '')
+MQTT_PASSWD = environ.get('MQTT_PASSWD', '')
 MQTT_HOST = environ.get('MQTT_HOST', 'localhost')
 MQTT_PORT = int(environ.get('MQTT_PORT', '1883'))
 MQTT_TIMEOUT = int(environ.get('MQTT_TIMEOUT', '300'))
@@ -47,6 +49,7 @@ for host in HOSTLIST.split(','):
 
 
 mqtt = paho.mqtt.client.Client()
+mqtt.username_pw_set(username=MQTT_USER,password=MQTT_PASSWD)
 mqtt.will_set("ping/status", "offline", qos=MQTT_QOS, retain=True)
 mqtt.connect(MQTT_HOST, MQTT_PORT, MQTT_TIMEOUT)
 mqtt.publish('ping/status', 'online', qos=MQTT_QOS, retain=True)


### PR DESCRIPTION
Tested on both a broker with and without auth. Working either way.