### PR TITLE
Docker image: multi-platform & simplification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
-FROM debian:stable
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
+FROM python:3-slim-bullseye
 
-# Pre-reqs
-RUN apt update && \
-    apt install --no-install-recommends -y python3-paho-mqtt python3-pip python3-setuptools && \
-    rm -rf /var/lib/apt/lists/*
-RUN pip3 install icmplib
+WORKDIR /usr/src/app
 
-# Copy files into place
-COPY ping2mqtt /
+COPY requirements.txt /usr/src/app
+COPY ping2mqtt /usr/src/app
 
-# Set the entrypoint
-ENTRYPOINT ["/ping2mqtt"]
+RUN pip3 install -r requirements.txt
+
+ENTRYPOINT ["python3", "ping2mqtt"]


### PR DESCRIPTION
Hi,

with this PR the Docker image
- is based on the official python docker image (slim python3 bullseye variant) which allows ping2mqtt to run on different platforms, e.g., ARM-based CPUs. This also (slightly) reduces the overall image size.
- uses the already existing `requirements.txt` to download the dependencies rather than duplicating the dependency definitions in the `Dockerfile`

Let me know if you have any concerns:)

If you're interested, I'd be happy to create a pull-request that uses GitHub Actions to automatically build and publish a multi-platform image.

You'd only have to configure two secrets in the repository: your dockerhub username and an access token to the dockerhub repo.
Similar to this in another github repo of mine:
![image](https://user-images.githubusercontent.com/11045082/132986300-8ea899f4-4b04-470d-86e4-ad97e637c885.png)
